### PR TITLE
Options for only interaxtions or only non-linearity

### DIFF
--- a/R/makePolyTerms.r
+++ b/R/makePolyTerms.r
@@ -15,7 +15,7 @@
 ##   polynomial expansion, and each entry ij is the degree of raw term i in
 ##   expansion term j
 ##
-makePolyTerms <- function(degree, k_expand, k_lin, binary_cols, names. = NULL)
+makePolyTerms <- function(degree, k_expand, k_lin, binary_cols,  names. = NULL)
 {
     ## Call C++ routine to compute the full set of potential polynomial terms
     ans <- computePolyTerms(degree, k_expand, k_lin)
@@ -53,6 +53,6 @@ makePolyTerms <- function(degree, k_expand, k_lin, binary_cols, names. = NULL)
         })
         rownames(ans) <- termNames
     }
-
+    
     ans
 }

--- a/R/polywog.r
+++ b/R/polywog.r
@@ -199,6 +199,8 @@ polywog <- function(formula,
                     weights,
                     na.action,
                     degree = 3,
+                    noint = FALSE, 
+                    onlyint = FALSE, 
                     family = c("gaussian", "binomial"),
                     method = c("alasso", "scad"),
                     penwt.method = c("lm", "glm"),
@@ -256,7 +258,13 @@ polywog <- function(formula,
                                k_lin = attr(X, "k_lin"),
                                binary_cols = attr(X, "binary_cols"),
                                names. = colnames(X))
-
+    if(noint){
+        polyTerms <- polyTerms[which(apply(polyTerms, 1, function(x)sum(x!= 0)) == 1), ]
+    }
+    if(onlyint){
+        polyTerms <- polyTerms[-which(apply(polyTerms, 1, function(x)sum(x!= 0)) == 1 & 
+        rowSums(polyTerms) > 1), ]
+    }
     ## Extract weights if any (same code as in 'lm')
     w <- as.vector(model.weights(mf))
     if (!is.null(w) && !is.numeric(w))

--- a/man/polywog.Rd
+++ b/man/polywog.Rd
@@ -2,13 +2,14 @@
 \alias{polywog}
 \title{Polynomial regression with oracle variable selection}
 \usage{
-polywog(formula, data, subset, weights, na.action, degree = 3,
-  family = c("gaussian", "binomial"), method = c("alasso", "scad"),
-  penwt.method = c("lm", "glm"), unpenalized = character(0),
-  .parallel = FALSE, boot = 0, control.boot = control.bp(.parallel =
-  .parallel), lambda = NULL, nlambda = 100, lambda.min.ratio = 1e-04,
-  nfolds = 10, foldid = NULL, thresh = ifelse(method == "alasso", 1e-07,
-  0.001), maxit = ifelse(method == "alasso", 1e+05, 5000), model = TRUE,
+polywog(formula, data, subset, weights, na.action, degree = 3, 
+  noint = FALSE, onlyint = FALSE, family = c("gaussian", "binomial"), 
+  method = c("alasso", "scad"), penwt.method = c("lm", "glm"), 
+  unpenalized = character(0), .parallel = FALSE, boot = 0, 
+  control.boot = control.bp(.parallel=.parallel), lambda = NULL, 
+  nlambda = 100, lambda.min.ratio = 1e-04, nfolds = 10, foldid = NULL, 
+  thresh = ifelse(method == "alasso", 1e-07, 0.001), 
+  maxit = ifelse(method == "alasso", 1e+05, 5000), model = TRUE,
   X = FALSE, y = FALSE)
 }
 \arguments{
@@ -30,6 +31,14 @@ polywog(formula, data, subset, weights, na.action, degree = 3,
 
   \item{degree}{integer specifying the degree of the
   polynomial expansion of the input variables.}
+
+  \item{noint}{Logical indicating whether (if \code{FALSE}) or 
+  not (if \code{TRUE}) interactions should be included in 
+  the design matrix.  }
+
+  \item{onlyint}{Logical indicating whether (if \code{FALSE}) or 
+  not (if \code{TRUE}) polynomials beyond first degree should be 
+  included in the design matrix.}
 
   \item{family}{\code{"gaussian"} (default) or
   \code{"binomial"} for logistic regression (binary


### PR DESCRIPTION
Hi Brenton, 

I've been using `polywog` for some work I've been doing, but I needed it to be able to use only additive polynomials or only linear interactions up to the desired degree.  I implemented this in my fork of the repository, but wondered if you might consider making this a feature in the official release?  I am happy to discuss further if you like. 

Thanks, 
Dave. 